### PR TITLE
feat: gateway refresh api 호출 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
 	implementation("org.springframework.boot:spring-boot-starter-web")
+	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/src/main/kotlin/io/maaaae/panama_canal/dto/dynamic_route_config/DynamicRouteConfigEvent.kt
+++ b/src/main/kotlin/io/maaaae/panama_canal/dto/dynamic_route_config/DynamicRouteConfigEvent.kt
@@ -1,0 +1,7 @@
+package io.maaaae.panama_canal.dto.dynamic_route_config
+
+data class DynamicRouteConfigEvent (
+    val message: String,
+    val timestamp: Long = System.currentTimeMillis()
+){
+}

--- a/src/main/kotlin/io/maaaae/panama_canal/dto/route_config/RouteConfigDto.kt
+++ b/src/main/kotlin/io/maaaae/panama_canal/dto/route_config/RouteConfigDto.kt
@@ -1,8 +1,0 @@
-package io.maaaae.panama_canal.dto.route_config
-
-data class RouteConfigDto(
-    val uri: String,
-    val predicates: String,
-    val filters: String,
-    val routeOrder: Int,
-)

--- a/src/main/kotlin/io/maaaae/panama_canal/service/dynamic_route_config/DynamicRouteConfigService.kt
+++ b/src/main/kotlin/io/maaaae/panama_canal/service/dynamic_route_config/DynamicRouteConfigService.kt
@@ -16,4 +16,6 @@ interface DynamicRouteConfigService {
 
     fun updateDynamicRouteConfig(id: Long, request: DynamicRouteConfigUpdateRequest)
     fun getDynamicRouteConfigOptions(): List<DynamicRouteConfigOptions>
+
+    fun publishEvent(message: String)
 }

--- a/src/main/kotlin/io/maaaae/panama_canal/service/dynamic_route_config/DynamicRouteConfigServiceImpl.kt
+++ b/src/main/kotlin/io/maaaae/panama_canal/service/dynamic_route_config/DynamicRouteConfigServiceImpl.kt
@@ -1,17 +1,12 @@
 package io.maaaae.panama_canal.service.dynamic_route_config
 
 import io.maaaae.panama_canal.common.exception.ResourceNotFoundException
-import io.maaaae.panama_canal.dto.dynamic_route_config.DynamicRouteConfigRequest
-import io.maaaae.panama_canal.dto.dynamic_route_config.DynamicRouteConfigResponse
-import io.maaaae.panama_canal.dto.dynamic_route_config.DynamicRouteConfigUpdateRequest
-import io.maaaae.panama_canal.dto.dynamic_route_config.DynamicRouteConfigOptions
-import io.maaaae.panama_canal.dto.dynamic_route_config.toDynamicRouteConfigEntity
-import io.maaaae.panama_canal.dto.dynamic_route_config.toDynamicRouteConfigResponse
-import io.maaaae.panama_canal.dto.dynamic_route_config.toSimpleDynamicRouteConfigResponse
+import io.maaaae.panama_canal.dto.dynamic_route_config.*
 import io.maaaae.panama_canal.dto.filter_config.toCreateEntity
 import io.maaaae.panama_canal.repository.dynamic_route_config.DynamicRouteConfigRepository
 import io.maaaae.panama_canal.repository.filter_config.FilterConfigRepository
 import io.maaaae.panama_canal.service.filter_config.FilterConfigService
+import org.springframework.context.ApplicationEventPublisher
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -21,6 +16,7 @@ class DynamicRouteConfigServiceImpl(
     private val dynamicRouteConfigRepository: DynamicRouteConfigRepository,
     private val filterConfigRepository: FilterConfigRepository,
     private val filterConfigService: FilterConfigService,
+    private val eventPublisher: ApplicationEventPublisher
 ) : DynamicRouteConfigService {
 
 
@@ -29,6 +25,7 @@ class DynamicRouteConfigServiceImpl(
         val createdRouteConfig = dynamicRouteConfigRepository.save(dynamicRouteConfigRequest.toDynamicRouteConfigEntity())
         val targetFilters = dynamicRouteConfigRequest.filters.map { it.toCreateEntity(createdRouteConfig) }
         filterConfigRepository.saveAll(targetFilters)
+            .apply { publishEvent("dynamic route config ${createdRouteConfig.id} created.") }
     }
 
 
@@ -53,12 +50,20 @@ class DynamicRouteConfigServiceImpl(
 
         // TODO: 필터에 대한 업데이트 및 삭제를 어떻게 할것인지 확인이 필요함.
         request.filters?.forEach { filterConfigService.updateFilterConfig(it) }
+        publishEvent("dynamic route config updated.")
     }
 
     @Transactional
     override fun deleteDynamicRouteConfig(id: Long) {
         val routeConfig = dynamicRouteConfigRepository.findByIdOrNull(id)
             ?: throw ResourceNotFoundException("Dynamic Route not found. id: $id")
-        dynamicRouteConfigRepository.delete(routeConfig)
+        dynamicRouteConfigRepository.delete(routeConfig).apply {
+            publishEvent("dynamic route config $id deleted.")
+        }
+    }
+
+    override fun publishEvent(message: String) {
+        val event = DynamicRouteConfigEvent(message)
+        eventPublisher.publishEvent(event)
     }
 }

--- a/src/main/kotlin/io/maaaae/panama_canal/service/gateway/GatewayApiCaller.kt
+++ b/src/main/kotlin/io/maaaae/panama_canal/service/gateway/GatewayApiCaller.kt
@@ -1,0 +1,26 @@
+package io.maaaae.panama_canal.service.gateway
+
+import io.maaaae.panama_canal.dto.dynamic_route_config.DynamicRouteConfigEvent
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.WebClient
+
+@Service
+class GatewayApiCaller(
+    @Value("\${gateway.url}") private val baseUrl: String
+) {
+
+    private val webClient = WebClient.builder().baseUrl(baseUrl).build()
+
+    @EventListener
+    fun handleDynamicRouteConfigEvent(event: DynamicRouteConfigEvent) {
+        println("Received event with message: ${event.message}")
+
+        webClient.post()
+            .uri("/routes/refresh")
+            .retrieve()
+            .bodyToMono(Void::class.java)
+            .block()
+    }
+}

--- a/src/main/kotlin/io/maaaae/panama_canal/service/route_config/RouteConfigService.kt
+++ b/src/main/kotlin/io/maaaae/panama_canal/service/route_config/RouteConfigService.kt
@@ -1,7 +1,0 @@
-package io.maaaae.panama_canal.service.route_config
-
-import io.maaaae.panama_canal.dto.route_config.RouteConfigDto
-
-interface RouteConfigService {
-    fun getAllRouteConfigs(): List<RouteConfigDto>
-}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
     driverClassName: ${SPRING_DATASOURCE_DRIVER_CLASS_NAME:org.sqlite.JDBC}
   jpa:
     hibernate:
-      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:create}
+      ddl-auto: ${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
     show-sql: ${SPRING_JPA_SHOW_SQL:true}
     database-platform: ${SPRING_JPA_DATABASE_PLATFORM:org.hibernate.community.dialect.SQLiteDialect}
   security:
@@ -34,3 +34,7 @@ logging:
 
 server:
   port: ${PORT:8080}
+
+
+gateway:
+  url: ${GATEWAY_URL:http://localhost:8888}


### PR DESCRIPTION
- 내부 이벤트 핸들링방식으로 구현했음
- 백엔드 api 통해 게이트웨이 설정값 디비에 업데이트 삭제 등이 발생하면 게이트웨이의 설정값이 새로고침되도록 함

- 안쓰는 클래스를 삭제 (RouteConfig)